### PR TITLE
Add xants to ssins

### DIFF
--- a/pipelines/h4c/rtp/v1/h4c_rtp_stage_1.toml
+++ b/pipelines/h4c/rtp/v1/h4c_rtp_stage_1.toml
@@ -349,7 +349,7 @@ stride_length = "all"
 time_centered = false
 
 [SSINS]
-prereqs = ["LIBRARIAN_MAKE_SESSION","ANT_METRICS","AUTO_METRICS"]
+prereqs = ["ANT_METRICS", "AUTO_METRICS"]
 mem = 36000
 args = ["${SSINS_OPTS:streak_sig}",
         "${SSINS_OPTS:other_sig}",

--- a/pipelines/h4c/rtp/v1/h4c_rtp_stage_1.toml
+++ b/pipelines/h4c/rtp/v1/h4c_rtp_stage_1.toml
@@ -349,11 +349,12 @@ stride_length = "all"
 time_centered = false
 
 [SSINS]
-prereqs = "LIBRARIAN_MAKE_SESSION"
+prereqs = ["LIBRARIAN_MAKE_SESSION","ANT_METRICS","AUTO_METRICS"]
 mem = 36000
 args = ["${SSINS_OPTS:streak_sig}",
         "${SSINS_OPTS:other_sig}",
         "${SSINS_OPTS:tb_aggro}",
+        "${ANT_METRICS_OPTS:extension}",
         "{obsid_list}"
        ]
 stride_length = 10

--- a/pipelines/h4c/rtp/v1/stage_1_task_scripts/do_SSINS.sh
+++ b/pipelines/h4c/rtp/v1/stage_1_task_scripts/do_SSINS.sh
@@ -44,7 +44,7 @@ for fn in ${data_files[@]}; do
     ant_metrics_files+=( ${fn%.uvh5}${4} )
 done
 
-echo Run_HERA_SSINS.py -f "${fns[@]}" -s $streak_sig -o $other_sig -p $prefix -t $tb_aggro -c
+echo Run_HERA_SSINS.py -f "${fns[@]}" -s $streak_sig -o $other_sig -p $prefix -t $tb_aggro --metrics_files ${auto_metrics_file} ${ant_metrics_files[@]} -c
 Run_HERA_SSINS.py -f "${fns[@]}" -s $streak_sig -o $other_sig -p $prefix -t $tb_aggro --metrics_files ${auto_metrics_file} ${ant_metrics_files[@]} -c
 
 # Move all outputs to folder

--- a/pipelines/h4c/rtp/v1/stage_1_task_scripts/do_SSINS.sh
+++ b/pipelines/h4c/rtp/v1/stage_1_task_scripts/do_SSINS.sh
@@ -20,18 +20,19 @@ all_args=("$@")
 streak_sig=${1}
 other_sig=${2}
 tb_aggro=${3}
-fns=("${all_args[@]:3}")
-data_files="${@:5}"
+data_files=(${@:5})
 
-echo filenames are "${fns[@]}"
+echo filenames are "${data_files[@]}"
 
 # Get the first filename in the list (should work if only one file)
-first_file="${fns%" "*}"
+first_file="${data_files%" "*}"
 # Set the prefix based on the first filename
 prefix="${first_file%.uvh5}"
 
 # get auto_metrics_file to exclude bad antennas
-jd=$(get_int_jd ${data_files[0]})
+fn=${data_files[0]}
+bn=`basename ${fn}`
+jd=$(get_int_jd ${bn})
 decimal_jd=$(get_jd ${data_files[0]})
 pattern="${fn%${decimal_jd}.sum.uvh5}${jd}.?????.sum.auto_metrics.h5"
 pattern_files=( $pattern )

--- a/pipelines/h4c/rtp/v1/stage_1_task_scripts/do_SSINS.sh
+++ b/pipelines/h4c/rtp/v1/stage_1_task_scripts/do_SSINS.sh
@@ -44,8 +44,8 @@ for fn in ${data_files[@]}; do
     ant_metrics_files+=( ${fn%.uvh5}${4} )
 done
 
-echo Run_HERA_SSINS.py -f "${fns[@]}" -s $streak_sig -o $other_sig -p $prefix -t $tb_aggro --metrics_files ${auto_metrics_file} ${ant_metrics_files[@]} -c
-Run_HERA_SSINS.py -f "${fns[@]}" -s $streak_sig -o $other_sig -p $prefix -t $tb_aggro --metrics_files ${auto_metrics_file} ${ant_metrics_files[@]} -c
+echo Run_HERA_SSINS.py -f ${data_files[@]} -s $streak_sig -o $other_sig -p $prefix -t $tb_aggro --metrics_files ${auto_metrics_file} ${ant_metrics_files[@]} -c
+Run_HERA_SSINS.py -f ${data_files[@]} -s $streak_sig -o $other_sig -p $prefix -t $tb_aggro --metrics_files ${auto_metrics_file} ${ant_metrics_files[@]} -c
 
 # Move all outputs to folder
 echo rm -rf ${prefix}.SSINS


### PR DESCRIPTION
Update `DO_SSINS.sh` and `h4c_rtp_stage_1.toml` so that `Run_HERA_SSINS.py` takes in ant_metrics and auto_metrics and uses `metrics_io` to get a list of xants to exclude from flagging. 

Note that ssins needs to be updated and reinstalled in order for these changes to work properly.