### PR TITLE
Validation uncalibrate

### DIFF
--- a/pipelines/validation/h1c_idr3_2/h1c_idr3_v2_validation.toml
+++ b/pipelines/validation/h1c_idr3_2/h1c_idr3_v2_validation.toml
@@ -8,6 +8,14 @@ base_mem = 8000
 base_cpu = 1
 timeout = "24h"
 
+[UNCALIBRATE_OPTS]
+sky_cmp = "foreground"
+path_to_sim_configs = "/lustre/aoc/projects/hera/Validation/H1C_IDR3/configs"
+path_to_sim_files = "/lustre/aoc/projects/hera/Validation/H1C_IDR3/chunked_data"
+path_to_scripts = "/lustre/aoc/projects/hera/Validation/H1C_IDR3/scripts"
+path_to_data_files = "/lustre/aoc/projects/hera/H1C_IDR3/IDR3_2"
+save_dir_base = "/lustre/aoc/projects/hera/Validation/test-4.1.0"
+
 [NOTEBOOK_OPTS]
 nb_template_dir = '/lustre/aoc/projects/hera/Validation/test-4.1.0/software/hera_notebook_templates/notebooks'
 nb_output_repo = '/lustre/aoc/projects/hera/Validation/test-4.1.0/h1c_idr3_validation_notebooks'
@@ -63,7 +71,8 @@ framesize = "1280x720"
 ############################################################################################################
 
 [WorkFlow]
-actions = ["EXTRACT_AUTOS",
+actions = ["UNCALIBRATE",
+           "EXTRACT_AUTOS",
            "DATA_INSPECT_NOTEBOOK",
            "REDCAL",
            "REDCAL_INSPECT_NOTEBOOK",
@@ -78,7 +87,19 @@ actions = ["EXTRACT_AUTOS",
            # "CLEAN_FILES", # TODO: update this and put it back in
           ]
 
+[UNCALIBRATE]
+args = ["{basename}",
+        "${UNCALIBRATE_OPTS:sky_cmp}",
+        "${UNCALIBRATE_OPTS:path_to_sim_configs}",
+        "${UNCALIBRATE_OPTS:path_to_sim_files}",
+        "${UNCALIBRATE_OPTS:path_to_scripts}",
+        "${UNCALIBRATE_OPTS:path_to_data_files}",
+        "${UNCALIBRATE_OPTS:save_dir_base}",
+       ]
+
 [EXTRACT_AUTOS]
+prereqs = "UNCALIBRATE"
+prereq_chunk_size = "all"  # Does this need to be set?
 args = ["{basename}"]
 
 [DATA_INSPECT_NOTEBOOK]

--- a/pipelines/validation/h1c_idr3_2/h1c_idr3_v2_validation.toml
+++ b/pipelines/validation/h1c_idr3_2/h1c_idr3_v2_validation.toml
@@ -2,6 +2,8 @@
 makeflow_type = "analysis"
 path_to_do_scripts = "/lustre/aoc/projects/hera/Validation/test-4.1.0/software/hera_pipelines/pipelines/validation/h1c_idr3_2/task_scripts"
 path_to_a_priori_flags = "/lustre/aoc/projects/hera/H1C_IDR3/IDR3_2/h1c_idr3_software/hera_pipelines/pipelines/h1c/idr3/v2/a_priori_flags"
+path_to_sim_files = "/lustre/aoc/projects/hera/Validation/H1C_IDR3/chunked_data"
+path_to_sim_configs = "/lustre/aoc/projects/hera/Validation/test-4.1.0/configs"
 conda_env = "h1c_idr3_2_validation"
 source_script = "~/.bashrc"
 base_mem = 8000
@@ -63,7 +65,8 @@ framesize = "1280x720"
 ############################################################################################################
 
 [WorkFlow]
-actions = ["EXTRACT_AUTOS",
+actions = ["UNCALIBRATE",
+           "EXTRACT_AUTOS",
            "DATA_INSPECT_NOTEBOOK",
            "REDCAL",
            "REDCAL_INSPECT_NOTEBOOK",
@@ -78,7 +81,12 @@ actions = ["EXTRACT_AUTOS",
            # "CLEAN_FILES", # TODO: update this and put it back in
           ]
 
+[UNCALIBRATE]
+args = ["{basename}"]
+
 [EXTRACT_AUTOS]
+prereqs = "UNCALIBRATE"
+prereq_chunk_size = "all"
 args = ["{basename}"]
 
 [DATA_INSPECT_NOTEBOOK]

--- a/pipelines/validation/h1c_idr3_2/h1c_idr3_v2_validation.toml
+++ b/pipelines/validation/h1c_idr3_2/h1c_idr3_v2_validation.toml
@@ -2,8 +2,6 @@
 makeflow_type = "analysis"
 path_to_do_scripts = "/lustre/aoc/projects/hera/Validation/test-4.1.0/software/hera_pipelines/pipelines/validation/h1c_idr3_2/task_scripts"
 path_to_a_priori_flags = "/lustre/aoc/projects/hera/H1C_IDR3/IDR3_2/h1c_idr3_software/hera_pipelines/pipelines/h1c/idr3/v2/a_priori_flags"
-path_to_sim_files = "/lustre/aoc/projects/hera/Validation/H1C_IDR3/chunked_data"
-path_to_sim_configs = "/lustre/aoc/projects/hera/Validation/test-4.1.0/configs"
 conda_env = "h1c_idr3_2_validation"
 source_script = "~/.bashrc"
 base_mem = 8000
@@ -106,7 +104,6 @@ args = ["{basename}"]
 
 [DATA_INSPECT_NOTEBOOK]
 prereqs = "EXTRACT_AUTOS"
-prereq_chunk_size = "all"
 chunk_size = 1
 stride_length = "all"
 time_centered = false
@@ -119,6 +116,7 @@ args = ["{basename}",
        ]
 
 [REDCAL]
+prereqs = "UNCALIBRATE"
 args = ["{basename}",
         "${REDCAL_OPTS:ant_z_thresh}",
         "${REDCAL_OPTS:solar_horizon}",

--- a/pipelines/validation/h1c_idr3_2/task_scripts/do_UNCALIBRATE.sh
+++ b/pipelines/validation/h1c_idr3_2/task_scripts/do_UNCALIBRATE.sh
@@ -1,0 +1,48 @@
+#! /bin/bash
+set -e
+
+# This script simulates and applies systematics to an input file.
+# Note that the path to where the perfectly calibrated files are stored
+# is contained in the mock_data.py script.
+
+# import common functions
+src_dir="$(dirname "$0")"
+source ${src_dir}/_common.sh
+
+# Parameters are set in the configuration file, here we define their positions,
+# which must be consistent with the config.
+# 1 - reference filename
+# 2 - sky component (e.g. foreground)
+# 3 - path to configuration files
+# 4 - path to where the uncalibration script lives
+# 5 - path to the IDR3.2 data products
+# 6 - path to where all the calibration products etc. will be saved
+
+fn="${1}"
+sky_cmp="${2}"
+config_path="${3}"
+script_dir="${4}"
+data_dir="${5}"
+save_dir_base="${6}"
+
+# Get the data filename correct, then append the data path.
+jd_int=$(get_int_jd `basename ${uvh5_fn}`)
+uvh5_fn=$(remove_pol $fn)
+uvh5_fn="${data_dir}/${jd_int}/${uvh5_fn%.HH.uv}.sum.autos.uvh5"
+
+# Figure out which configuration file to use.
+config_file="${config_path}/${jd_int}.yaml"
+
+# Figure out where to write the new data.
+outdir="${save_dir_base}/${jd_int}"
+
+# Remember where we came from, and move to where we need to be.
+cwd="$(pwd)"
+cd $script_dir
+
+# Do the interpolation and systematics simulation.
+echo python mock_data.py ${uvh5_fn} ${sky_cmp} --config ${config_file} \
+                         --outdir ${save_dir} --clobber --inflate
+python mock_data.py ${uvh5_fn} ${sky_cmp} --config ${config_file} \
+                    --outdir ${save_dir} --clobber --inflate
+cd $cwd

--- a/pipelines/validation/h1c_idr3_2/task_scripts/do_UNCALIBRATE.sh
+++ b/pipelines/validation/h1c_idr3_2/task_scripts/do_UNCALIBRATE.sh
@@ -1,0 +1,43 @@
+#! /bin/bash
+set -e
+
+# This script simulates and applies systematics to an input file.
+
+# import common functions
+src_dir="$(dirname "$0")"
+source ${src_dir}/_common.sh
+
+# Parameters are set in the configuration file, here we define their positions,
+# which must be consistent with the config.
+# 1 - filename: reference filename
+# 2 - config_path: path to configuration files
+# 3 - data_path: path to raw simulation data
+# 4 -
+# 5 -
+# 6 -
+# 7 -
+# 8 -
+# 9 -
+# 10 -
+# 11 - 
+# 12 - 
+
+fn="${1}"
+config_path="${2}"
+data_path="${3}"
+
+# make sure input file is correct uvh5 file
+uvh5_fn=$(remove_pol $fn)
+uvh5_fn=${uvh5_fn%.HH.uv}.sum.uvh5 # this makes things more compatible with H3C/H4C software
+
+# get systematic parameter yaml
+jd_int=$(get_int_jd `basename ${uvh5_fn}`)
+config_file="${config_path}/${jd_int}.yaml"
+
+cwd="$(pwd)"
+cd $script_dir
+
+# run systematics simulation
+echo python apply_systematics.py ${uvh5_fn} --config ${config_file} # and so on
+python apply_systematics.py ${uvh5_fn} --config ${config_file} # and so on
+cd $cwd


### PR DESCRIPTION
Quick overview of what this step does:
1) Takes a miriad-style file (e.g. `zen.???????.?????.{pol}.HH.uv`) and a handful of paths for finding required files
2) Finds relevant simulation data, interpolates it to the times in the associated real data autocorrelation file, selecting only antennas that are in the real data for that day and are not in the list of bad antennas.
3) Simulates and applies systematic effects from configuration files prepared beforehand (the location of these is specified in the toml).
4) Writes the "uncalibrated" file in the "working folder" for the makeflow (specified in the toml) with the naming convention `zen.???????.?????.sum.uvh5`.