### PR TITLE
H4C Nsamples Changes

### DIFF
--- a/pipelines/h4c/idr2.3/lstbin/task_scripts/do_LSTBIN.sh
+++ b/pipelines/h4c/idr2.3/lstbin/task_scripts/do_LSTBIN.sh
@@ -107,10 +107,10 @@ fi
 echo lstbin_run.py --flag_thresh ${flag_thresh}  ${red_arg} --dlst ${dlst} --file_ext ${file_ext}\
  --outdir ${outdir} --ntimes_per_file ${ntimes_per_file} ${rephase} ${sig_clip} --sigma ${sigma}\
   --min_N ${min_N} --lst_start ${lst_start} ${fixed_lst_start} --vis_units ${vis_units}\
-   --output_file_select ${output_file_select} --Nbls_to_load ${Nbls_to_load}\
+   --output_file_select ${output_file_select} --Nbls_to_load ${Nbls_to_load} --weight_only_by_flags\
    ${yaml_arg} ${input_cals} --overwrite ${data_files[@]}
 lstbin_run.py --flag_thresh ${flag_thresh}  ${red_arg} --dlst ${dlst} --file_ext ${file_ext}\
     --outdir ${outdir} --ntimes_per_file ${ntimes_per_file} ${rephase} ${sig_clip} --sigma ${sigma}\
      --min_N ${min_N} --lst_start ${lst_start} ${fixed_lst_start} --vis_units ${vis_units}\
-      --output_file_select ${output_file_select} --Nbls_to_load ${Nbls_to_load}\
+      --output_file_select ${output_file_select} --Nbls_to_load ${Nbls_to_load} --weight_only_by_flags\
       ${yaml_arg} ${input_cals} --overwrite ${data_files[@]}

--- a/pipelines/h4c/idr2.3/pre_lstbin/h4c_idr2p2_postprocess_night.toml
+++ b/pipelines/h4c/idr2.3/pre_lstbin/h4c_idr2p2_postprocess_night.toml
@@ -71,7 +71,9 @@ filter_mode = "DPSS"
 # Note that these channels are indexed relative to the channels left over after selection
 # channels with Options:spw_ranges so this is why the "bottom of the FM" shows up as
 # one channel away from the "top of the FM" since the FM was already removed by Options:spw_ranges
-spw_ranges = "0~291,291~1028"
+# KFC: Separate into three delay windows
+# Originally: spw_ranges = "0~291,291~1028"
+spw_ranges = "0~291,291~853,853~1028"
 
 # we may want to consider another flagging round after delay filtering.
 [FR_OPTS]

--- a/pipelines/h4c/idr2.3/pre_lstbin/task_scripts/do_DELAY.sh
+++ b/pipelines/h4c/idr2.3/pre_lstbin/task_scripts/do_DELAY.sh
@@ -93,12 +93,12 @@ do
       then
         # Command for DPSS inpainting
         echo delay_filter_run.py ${fn_in}  \
-          --filled_outfilename ${fn_out} --clobber \
+          --filled_outfilename ${fn_out} --clobber --apply_flag_to_nsample\
           --res_outfilename ${fn_res} --CLEAN_outfilename ${fn_cln}  \
           --tol ${tol} --cache_dir ${cache_dir} --standoff ${standoff}  \
           --min_dly ${min_dly}  --mode dpss_leastsq --filter_spw_ranges ${spw_ranges} --flag_yaml ${flag_yaml}
         delay_filter_run.py ${fn_in}  \
-          --filled_outfilename ${fn_out} --clobber  \
+          --filled_outfilename ${fn_out} --clobber  --apply_flag_to_nsample\
           --res_outfilename ${fn_res} --CLEAN_outfilename ${fn_cln}  \
           --tol ${tol} --cache_dir ${cache_dir} --standoff ${standoff}  \
           --min_dly ${min_dly}  --mode dpss_leastsq --filter_spw_ranges ${spw_ranges} --flag_yaml ${flag_yaml}
@@ -107,13 +107,13 @@ do
         # Command for CLEAN inpainting
         npad=$((${spw1}-${spw0}))
         echo delay_filter_run.py ${fn_in}  \
-        --filled_outfilename ${fn_out} --clobber \
+        --filled_outfilename ${fn_out} --clobber --apply_flag_to_nsample\
         --res_outfilename ${fn_res} --CLEAN_outfilename ${fn_cln}  \
         --tol ${tol} --standoff ${standoff}   --filter_spw_ranges ${spw_ranges}\
         --min_dly ${min_dly} --edgecut_low ${npad} --edgecut_hi ${npad} --zeropad ${npad} --mode clean --flag_yaml ${flag_yaml}
 
         delay_filter_run.py ${fn_in} \
-        --filled_outfilename ${fn_out} --clobber \
+        --filled_outfilename ${fn_out} --clobber --apply_flag_to_nsample\
         --res_outfilename ${fn_res} --CLEAN_outfilename ${fn_cln}  \
         --tol ${tol} --standoff ${standoff}   --filter_spw_ranges ${spw_ranges}\
         --min_dly ${min_dly} --edgecut_low ${npad} --edgecut_hi ${npad} --zeropad ${npad} --mode clean --flag_yaml ${flag_yaml}


### PR DESCRIPTION
Some changes in the toml files / task scripts to enable carrying `nsamples` in our analysis. 
 - Change `SPW_DELAYS` to have three delay windows (one below FM, one between FM - DTV, one above DTV)
 - Enable `--apply_flag_to_nsample` so that the `nsamples` reflect the actual flagging patterns before going into delay filtering, see [`hera_cal` PR #929](https://github.com/HERA-Team/hera_cal/pull/929).
 - Enable `--weight_only_by_flags` so that during lst binning we still average inpainted data with real data, just keeping the inhomogeneous `nsamples` for stats purpose, see [`hera_cal` PR #932](https://github.com/HERA-Team/hera_cal/pull/932).

Expected behaviour is everything should be the same except for the `nsample` array. Might need some small-scale testing from potentially @lisaleemcb or @r-pascua?