### PR TITLE
Extract autos after LST binning

### DIFF
--- a/pipelines/h4c/post_processing/v7_interleave/post_lstbin_frate/h4c_idr1_filtering_allbands_for_lstbin_pspec_nocleanup_frate_filter.toml
+++ b/pipelines/h4c/post_processing/v7_interleave/post_lstbin_frate/h4c_idr1_filtering_allbands_for_lstbin_pspec_nocleanup_frate_filter.toml
@@ -76,7 +76,7 @@ prereqs = "PRE_CHUNK"
 prereq_chunk_size="all"
 chunk_size="all"
 mem=16000
-args=["${Options:label}"]
+args=["${Options:label}", "${Options:include_diffs}"]
 
 [FR_FILTER]
 prereqs = "PRE_CHUNK"

--- a/pipelines/h4c/post_processing/v7_interleave/post_lstbin_frate/h4c_idr1_filtering_allbands_for_lstbin_pspec_nocleanup_frate_filter.toml
+++ b/pipelines/h4c/post_processing/v7_interleave/post_lstbin_frate/h4c_idr1_filtering_allbands_for_lstbin_pspec_nocleanup_frate_filter.toml
@@ -55,6 +55,7 @@ max_plots_per_row = 10
 [WorkFlow]
 actions = [
            "PRE_CHUNK",
+           "EXTRACT_AUTOS",
            "FR_FILTER",
            "TIME_AVERAGE",
            "RECONSTITUTE",
@@ -69,6 +70,12 @@ chunk_size=1
 stride_length="${Options:chunk_size}"
 args=["{basename}", "${Options:include_diffs}", "${Options:label}",
     "${Options:chunk_size}"]
+
+[EXTRACT_AUTOS]
+prereqs = "PRE_CHUNK"
+prereq_chunk_size="all"
+mem=16000
+args=["${Options:label}"]
 
 [FR_FILTER]
 prereqs = "PRE_CHUNK"

--- a/pipelines/h4c/post_processing/v7_interleave/post_lstbin_frate/h4c_idr1_filtering_allbands_for_lstbin_pspec_nocleanup_frate_filter.toml
+++ b/pipelines/h4c/post_processing/v7_interleave/post_lstbin_frate/h4c_idr1_filtering_allbands_for_lstbin_pspec_nocleanup_frate_filter.toml
@@ -74,7 +74,8 @@ args=["{basename}", "${Options:include_diffs}", "${Options:label}",
 [EXTRACT_AUTOS]
 prereqs = "PRE_CHUNK"
 prereq_chunk_size="all"
-chunk_size="all"
+chunk_size=1
+stride_length=215
 mem=16000
 args=["${Options:label}", "${Options:include_diffs}"]
 

--- a/pipelines/h4c/post_processing/v7_interleave/post_lstbin_frate/h4c_idr1_filtering_allbands_for_lstbin_pspec_nocleanup_frate_filter.toml
+++ b/pipelines/h4c/post_processing/v7_interleave/post_lstbin_frate/h4c_idr1_filtering_allbands_for_lstbin_pspec_nocleanup_frate_filter.toml
@@ -74,6 +74,7 @@ args=["{basename}", "${Options:include_diffs}", "${Options:label}",
 [EXTRACT_AUTOS]
 prereqs = "PRE_CHUNK"
 prereq_chunk_size="all"
+chunk_size="all"
 mem=16000
 args=["${Options:label}"]
 

--- a/pipelines/h4c/post_processing/v7_interleave/post_lstbin_frate/task_scripts/do_EXTRACT_AUTOS.sh
+++ b/pipelines/h4c/post_processing/v7_interleave/post_lstbin_frate/task_scripts/do_EXTRACT_AUTOS.sh
@@ -16,5 +16,5 @@ do
     
     echo "python extract_autos_post_lstbin.py ${sd} ${label} --flist ${flist}"
     
-    python extract_autos.py ${flist}
+    python extract_autos.post_listbin.py ${flist}
 done

--- a/pipelines/h4c/post_processing/v7_interleave/post_lstbin_frate/task_scripts/do_EXTRACT_AUTOS.sh
+++ b/pipelines/h4c/post_processing/v7_interleave/post_lstbin_frate/task_scripts/do_EXTRACT_AUTOS.sh
@@ -12,9 +12,9 @@ sumdiff=("sum" "diff")
 
 for sd in ${sumdiff[@]}
 do
-    flist=$(ls *${sd}*chunked.uvh5)
+    flist=$(ls *${sd}.${label}.*chunked.uvh5)
     
-    echo "python extract_autos_post_lstbin.py ${sd} ${label} --flist ${flist}"
+    echo "python extract_autos_post_lstbin.py ${sd} ${label} --clobber --axis blt --flist ${flist}"
     
-    python extract_autos.post_listbin.py ${flist}
+    python extract_autos.post_listbin.py ${sd} ${label} --clobber --axis blt --flist ${flist}
 done

--- a/pipelines/h4c/post_processing/v7_interleave/post_lstbin_frate/task_scripts/do_EXTRACT_AUTOS.sh
+++ b/pipelines/h4c/post_processing/v7_interleave/post_lstbin_frate/task_scripts/do_EXTRACT_AUTOS.sh
@@ -16,5 +16,5 @@ do
     
     echo "python extract_autos_post_lstbin.py ${sd} ${label} --clobber --axis blt --flist ${flist}"
     
-    python extract_autos.post_listbin.py ${sd} ${label} --clobber --axis blt --flist ${flist}
+    python extract_autos_post_lstbin.py ${sd} ${label} --clobber --axis blt --flist ${flist}
 done

--- a/pipelines/h4c/post_processing/v7_interleave/post_lstbin_frate/task_scripts/do_EXTRACT_AUTOS.sh
+++ b/pipelines/h4c/post_processing/v7_interleave/post_lstbin_frate/task_scripts/do_EXTRACT_AUTOS.sh
@@ -1,0 +1,20 @@
+#! /bin/bash
+set -e
+
+#import common functions
+src_dir="$(dirname "$0")"
+source ${src_dir}/_common.sh
+
+# This script extracts the autocorrelations into a single waterfall file
+label=${1}
+
+sumdiff=("sum" "diff")
+
+for sd in ${sumdiff[@]}
+do
+    flist=$(ls *${sd}*chunked.uvh5)
+    
+    echo "python extract_autos_post_lstbin.py ${sd} ${label} --flist ${flist}"
+    
+    python extract_autos.py ${flist}
+done

--- a/pipelines/h4c/post_processing/v7_interleave/post_lstbin_frate/task_scripts/do_EXTRACT_AUTOS.sh
+++ b/pipelines/h4c/post_processing/v7_interleave/post_lstbin_frate/task_scripts/do_EXTRACT_AUTOS.sh
@@ -7,12 +7,28 @@ source ${src_dir}/_common.sh
 
 # This script extracts the autocorrelations into a single waterfall file
 label=${1}
+include_diffs=${2}
 
-sumdiff=("sum" "diff")
+if [ "${include_diffs}" = "true" ] 
+then
+    sumdiff=("sum" "diff")
+else
+    sumdiff=("sum")
+fi
 
 for sd in ${sumdiff[@]}
 do
-    flist=$(ls *${sd}.${label}.*chunked.uvh5)
+    # *Sigh* bash
+    # Use the return value of ls to see if it runs OK (don't want to pass an empty list for example)
+    # Redirect the output to die in /dev/null/ so it doesn't crowd the log
+    # Exit if there is an error.
+    if ls *${sd}.${label}.*chunked.uvh5 1> /dev/null 
+    then
+        flist=$(ls *${sd}.${label}.*chunked.uvh5)
+    else
+        echo "Error when calling ls on ${sd} files with label ${label}. Probably could not find files. Check error log. Exiting."
+        exit 1
+    fi
     
     echo "python extract_autos_post_lstbin.py ${sd} ${label} --clobber --axis blt --flist ${flist}"
     

--- a/scripts/extract_autos_post_lstbin.py
+++ b/scripts/extract_autos_post_lstbin.py
@@ -1,0 +1,52 @@
+#!/usr/bin/env python
+"""
+Pipeline script to extract autocorrelations from chunked files into waterfall.
+"""
+from hera_pspec import utils
+from pyuvdata import UVData
+from hera_cal._cli_tools import parse_args, run_with_profiling
+import warnings
+
+def main(args):
+    def check_for_sumdiff(file):
+        if not args.sumdiff in file:
+            raise ValueError(f"Supposedly processing {args.sumdiff} files but "
+                             f"{args.sumdiff} not in the filename.")
+        return
+    
+    # In case there are files without autos
+    found_autos = False
+    for file_ind, file in enumerate(args.flist):
+        check_for_sumdiff(file)
+        try:
+            main_uvd = UVData()
+            main_uvd.read(file, ant_str="auto")
+            found_autos = True
+            break
+        except ValueError: # There were no autos in that file
+            continue
+    
+    if found_autos:
+        start_ind = file_ind + 1
+        if start_ind < len(args.flist): 
+            for file in args.flist[file_ind + 1:]:
+                check_for_sumdiff(file)
+                try:
+                    new_uvd = UVData()
+                    new_uvd.read(file, ant_str="auto")
+                    main_uvd.__add__(new_uvd, inplace=True)
+                except ValueError:
+                    continue
+        else:
+            warnings.warn("Only one file had autocorrelatons. Inputs are almost "
+                          "certainly incorrect.")
+        
+        outfile = f"zen.LST.0.00000.{args.sumdiff}.{args.label}.foreground_filled.xtalk_filtered.chunked.waterfall.autos.uvh5"
+        main_uvd.write_uvh5(outfile, clobber=True)
+    else:
+        raise ValueError("No autocorrelations found in any files. Check inputs.")
+    
+parser = utils.extract_autos_post_lstbin_parser()
+args = parse_args(parser)
+run_with_profiling(main, args, args)
+

--- a/scripts/extract_autos_post_lstbin.py
+++ b/scripts/extract_autos_post_lstbin.py
@@ -31,10 +31,10 @@ def main(args):
         Check that a file being read is part of the intended group. Error if not,
         since something has been passed incorrectly.
         """
-        if not args.sumdiff in file:
+        if args.sumdiff not in file:
             raise ValueError(f"Supposedly processing {args.sumdiff} files but "
                              f"{args.sumdiff} not in the filename.")
-        if not args.label in file:
+        if args.label not in file:
             raise ValueError(f"Supposedly processing {args.label} files but "
                              f"{args.label} not in the filename.")
         return
@@ -43,15 +43,13 @@ def main(args):
     files_with_autos = []
     for file in args.flist:
         check_for_sumdiff_label(file)
-        test_uvd = UVData()
-        test_uvd.read(file, read_data=False)
+        test_uvd = UVData.from_file(file, read_data=False)
         if np.any(test_uvd.ant_1_array == test_uvd.ant_2_array):
             files_with_autos.append(file)
     
     assert len(files_with_autos) > 0, "No files with autos found. Check inputs."
 
-    auto_uvd = UVData() 
-    auto_uvd.read(files_with_autos, ant_str="auto", axis=args.axis)
+    auto_uvd = UVData.from_file(files_with_autos, ant_str="auto", axis=args.axis)
     
     # Just formatting this string so it doesn't make a long line
     prefix = "zen.LST.0.00000"

--- a/scripts/extract_autos_post_lstbin.py
+++ b/scripts/extract_autos_post_lstbin.py
@@ -39,9 +39,13 @@ def main(args):
                              f"{args.label} not in the filename.")
         return
     
+
+    # Sort this list so axis=blt doesn't break
+    flist = sorted(args.flist) if args.axis == "blt" else args.flist
+
     # Go through and find all files that have autos using metadata reads
     files_with_autos = []
-    for file in args.flist:
+    for file in flist:
         check_for_sumdiff_label(file)
         test_uvd = UVData.from_file(file, read_data=False)
         if np.any(test_uvd.ant_1_array == test_uvd.ant_2_array):
@@ -52,7 +56,7 @@ def main(args):
     auto_uvd = UVData.from_file(files_with_autos, ant_str="auto", axis=args.axis)
     
     # Just formatting this string so it doesn't make a long line
-    prefix = "zen.LST.0.00000."
+    prefix = "zen.LST.0.00000"
     suffix = "foreground_filled.waterfall.autos.uvh5"
     outfile = f"{prefix}.{args.sumdiff}.{args.label}.{suffix}"
     auto_uvd.write_uvh5(outfile, clobber=args.clobber)

--- a/scripts/extract_autos_post_lstbin.py
+++ b/scripts/extract_autos_post_lstbin.py
@@ -52,8 +52,8 @@ def main(args):
     auto_uvd = UVData.from_file(files_with_autos, ant_str="auto", axis=args.axis)
     
     # Just formatting this string so it doesn't make a long line
-    prefix = "zen.LST.0.00000"
-    suffix = "foreground_filled.xtalk_filtered.chunked.waterfall.autos.uvh5"
+    prefix = "zen.LST.0.00000."
+    suffix = "foreground_filled.waterfall.autos.uvh5"
     outfile = f"{prefix}.{args.sumdiff}.{args.label}.{suffix}"
     auto_uvd.write_uvh5(outfile, clobber=args.clobber)
 

--- a/scripts/extract_autos_post_lstbin.py
+++ b/scripts/extract_autos_post_lstbin.py
@@ -2,51 +2,66 @@
 """
 Pipeline script to extract autocorrelations from chunked files into waterfall.
 """
-from hera_pspec import utils
 from pyuvdata import UVData
 from hera_cal._cli_tools import parse_args, run_with_profiling
-import warnings
+import numpy as np
+import argparse
+
+
+def extract_autos_post_lstbin_parser():
+
+    parser = argparse.ArgumentParser(description="Argument parser for "
+                                     "autos from the chunked files into a "
+                                     "waterfall file.")
+    parser.add_argument("sumdiff", type=str, help="A string identifying whether"
+                        " the files are sum or diff files.")
+    parser.add_argument("label", type=str, help="The file label.")
+    parser.add_argument("--flist", type=str, nargs="*", 
+                        help="The list of chunked files.")
+    parser.add_argument("--axis", type=str, default=None, required=False,
+                        help="Can specify an axis for UVData.fast_concat. "
+                             "Default is None, so no fast_concat.")
+    parser.add_argument("--clobber", action="store_true", required=False,
+                        help="Whether to overwrite an existing autos file.")
+    return parser
 
 def main(args):
-    def check_for_sumdiff(file):
+    def check_for_sumdiff_label(file):
+        """
+        Check that a file being read is part of the intended group. Error if not,
+        since something has been passed incorrectly.
+        """
         if not args.sumdiff in file:
             raise ValueError(f"Supposedly processing {args.sumdiff} files but "
                              f"{args.sumdiff} not in the filename.")
+        if not args.label in file:
+            raise ValueError(f"Supposedly processing {args.label} files but "
+                             f"{args.label} not in the filename.")
         return
     
-    # In case there are files without autos
-    found_autos = False
-    for file_ind, file in enumerate(args.flist):
-        check_for_sumdiff(file)
-        try:
-            main_uvd = UVData()
-            main_uvd.read(file, ant_str="auto")
-            found_autos = True
-            break
-        except ValueError: # There were no autos in that file
-            continue
+    # Go through and find all files that have autos using metadata reads
+    files_with_autos = []
+    for file in args.flist:
+        check_for_sumdiff_label(file)
+        test_uvd = UVData()
+        test_uvd.read(file, read_data=False)
+        if np.any(test_uvd.ant_1_array == test_uvd.ant_2_array):
+            files_with_autos.append(file)
     
-    if found_autos:
-        start_ind = file_ind + 1
-        if start_ind < len(args.flist): 
-            for file in args.flist[file_ind + 1:]:
-                check_for_sumdiff(file)
-                try:
-                    new_uvd = UVData()
-                    new_uvd.read(file, ant_str="auto")
-                    main_uvd.__add__(new_uvd, inplace=True)
-                except ValueError:
-                    continue
-        else:
-            warnings.warn("Only one file had autocorrelatons. Inputs are almost "
-                          "certainly incorrect.")
-        
-        outfile = f"zen.LST.0.00000.{args.sumdiff}.{args.label}.foreground_filled.xtalk_filtered.chunked.waterfall.autos.uvh5"
-        main_uvd.write_uvh5(outfile, clobber=True)
-    else:
-        raise ValueError("No autocorrelations found in any files. Check inputs.")
+    assert len(files_with_autos) > 0, "No files with autos found. Check inputs."
+
+    auto_uvd = UVData() 
+    auto_uvd.read(files_with_autos, ant_str="auto", axis=args.axis)
     
-parser = utils.extract_autos_post_lstbin_parser()
+    # Just formatting this string so it doesn't make a long line
+    prefix = "zen.LST.0.00000"
+    suffix = "foreground_filled.xtalk_filtered.chunked.waterfall.autos.uvh5"
+    outfile = f"{prefix}.{args.sumdiff}.{args.label}.{suffix}"
+    auto_uvd.write_uvh5(outfile, clobber=args.clobber)
+
+    return
+    
+parser = extract_autos_post_lstbin_parser()
 args = parse_args(parser)
 run_with_profiling(main, args, args)
 


### PR DESCRIPTION
This adds a task script to the H4C analysis that extracts autocorrelations into a big waterfall mainly for the purposes of error propagation.

I am unsure as to whether I should have made a new toml, or tacked this on to the rerun branch.