### PR TITLE
Add frf noise cov

### DIFF
--- a/pipelines/h4c/post_processing/v7_interleave/post_lstbin_frate/h4c_idr1_filtering_allbands_for_lstbin_pspec_nocleanup_frate_filter.toml
+++ b/pipelines/h4c/post_processing/v7_interleave/post_lstbin_frate/h4c_idr1_filtering_allbands_for_lstbin_pspec_nocleanup_frate_filter.toml
@@ -106,7 +106,7 @@ prereqs = ["EXTRACT_AUTOS", "FR_FILTER"]
 prereq_chunk_size="all"
 mem=16000
 chunk_size=1
-stride_length=${Options:chunk_size}"
+stride_length="${Options:chunk_size}"
 args=["{basename}", "${Options:label}", "${FR_OPTS:tol}","${FR_opts:spw_ranges}",
       "${FR_OPTS:prefilter_zero_frate}", "${FR_OPTS:ninterleave}"]
 

--- a/pipelines/h4c/post_processing/v7_interleave/post_lstbin_frate/h4c_idr1_filtering_allbands_for_lstbin_pspec_nocleanup_frate_filter.toml
+++ b/pipelines/h4c/post_processing/v7_interleave/post_lstbin_frate/h4c_idr1_filtering_allbands_for_lstbin_pspec_nocleanup_frate_filter.toml
@@ -106,7 +106,7 @@ prereqs = ["EXTRACT_AUTOS", "FR_FILTER"]
 prereq_chunk_size="all"
 mem=16000
 chunk_size=1
-stride_length=${Options:chunk_size}$
+stride_length=${Options:chunk_size}"
 args=["{basename}", "${Options:label}", "${FR_OPTS:tol}","${FR_opts:spw_ranges}",
       "${FR_OPTS:prefilter_zero_frate}", "${FR_OPTS:ninterleave}"]
 

--- a/pipelines/h4c/post_processing/v7_interleave/post_lstbin_frate/h4c_idr1_filtering_allbands_for_lstbin_pspec_nocleanup_frate_filter.toml
+++ b/pipelines/h4c/post_processing/v7_interleave/post_lstbin_frate/h4c_idr1_filtering_allbands_for_lstbin_pspec_nocleanup_frate_filter.toml
@@ -58,6 +58,7 @@ actions = [
            "EXTRACT_AUTOS",
            "FR_FILTER",
            "TIME_AVERAGE",
+           "FRF_COV",
            "RECONSTITUTE",
            "PSTOKES",
            "PSPEC",
@@ -99,6 +100,15 @@ stride_length="${Options:chunk_size}"
 mem = 24000
 args = ["{basename}", "${Options:include_diffs}",
        "${Options:label}", "${Options:t_avg}", "${FR_OPTS:ninterleave}"]
+
+[FRF_COV]
+prereqs = "EXTRACT_AUTOS"
+prereq_chunk_size="all"
+mem=16000
+chunk_size=1
+stride_length=${Options:chunk_size}$
+args=["{basename}", "${Options:label}", "${FR_OPTS:tol}","${FR_opts:spw_ranges}",
+      "${FR_OPTS:prefilter_zero_frate}", "${FR_OPTS:ninterleave}"]
 
 [RECONSTITUTE]
 prereqs = "TIME_AVERAGE"

--- a/pipelines/h4c/post_processing/v7_interleave/post_lstbin_frate/h4c_idr1_filtering_allbands_for_lstbin_pspec_nocleanup_frate_filter.toml
+++ b/pipelines/h4c/post_processing/v7_interleave/post_lstbin_frate/h4c_idr1_filtering_allbands_for_lstbin_pspec_nocleanup_frate_filter.toml
@@ -102,7 +102,7 @@ args = ["{basename}", "${Options:include_diffs}",
        "${Options:label}", "${Options:t_avg}", "${FR_OPTS:ninterleave}"]
 
 [FRF_COV]
-prereqs = "EXTRACT_AUTOS"
+prereqs = ["EXTRACT_AUTOS", "FR_FILTER"]
 prereq_chunk_size="all"
 mem=16000
 chunk_size=1

--- a/pipelines/h4c/post_processing/v7_interleave/post_lstbin_frate/h4c_idr1_filtering_allbands_for_lstbin_pspec_nocleanup_frate_filter.toml
+++ b/pipelines/h4c/post_processing/v7_interleave/post_lstbin_frate/h4c_idr1_filtering_allbands_for_lstbin_pspec_nocleanup_frate_filter.toml
@@ -77,7 +77,7 @@ prereqs = "PRE_CHUNK"
 prereq_chunk_size="all"
 chunk_size=1
 stride_length=215
-mem=16000
+mem=64000
 args=["${Options:label}", "${Options:include_diffs}"]
 
 [FR_FILTER]

--- a/pipelines/h4c/post_processing/v7_interleave/post_lstbin_frate/task_scripts/do_FRF_COV.sh
+++ b/pipelines/h4c/post_processing/v7_interleave/post_lstbin_frate/task_scripts/do_FRF_COV.sh
@@ -16,12 +16,6 @@ ninterleave="${6}"
 #clobber="true"
 
 jd=$(get_jd $fn)
-int_jd=${jd:0:7}
-if [[ "$int_jd" == *"."* ]]; then
-  jd=`echo ${fn} | grep -o "[0-9]\{1,2\}.[0-9]\{5\}"`
-  int_jd="LST"
-  jd="LST.${jd}"
-fi
 
 
 # split up spw ranges.
@@ -36,12 +30,12 @@ else
   pf_arg=""
 fi
 
-
-waterfall_files=`echo zen.${int_jd}.*.sum.${label}.frf.waterfall.uvh5`
-if echo x"$waterfall_files" | grep '*' > /dev/null; then
+for spw_range in spw_ranges
+do
+  waterfall_file=`echo zen.${jd}.sum.${label}.frf.spw_range_${spw_range}.waterfall.uvh5`
+  if echo x"$waterfall_files" | grep '*' > /dev/null; then
 		echo "No waterfall files exist with ${jd}. This is probably because there are more times than baseline groups."
-else
-    echo ${ilabel}
+  else
     # Calculate FRF cov
     fn_out=zen.${jd}.sum.${label}.frf.tavg.cov.npy
 	
@@ -50,6 +44,6 @@ else
       --ninterleave ${ninterleave} ${pf_arg}"		   
     echo ${cmd}
 	${cmd}  
-fi
-	    
+  fi
+done	    
 

--- a/pipelines/h4c/post_processing/v7_interleave/post_lstbin_frate/task_scripts/do_FRF_COV.sh
+++ b/pipelines/h4c/post_processing/v7_interleave/post_lstbin_frate/task_scripts/do_FRF_COV.sh
@@ -31,7 +31,7 @@ else
   pf_arg=""
 fi
 
-for spw_range in spw_ranges
+for spw_range in ${spw_ranges[@]}
 do
   waterfall_file=`echo zen.${jd}.sum.${label}.frf.spw_range_${spw_range}.waterfall.uvh5`
   if echo x"$waterfall_files" | grep '*' > /dev/null; then

--- a/pipelines/h4c/post_processing/v7_interleave/post_lstbin_frate/task_scripts/do_FRF_COV.sh
+++ b/pipelines/h4c/post_processing/v7_interleave/post_lstbin_frate/task_scripts/do_FRF_COV.sh
@@ -40,7 +40,7 @@ do
     # Calculate FRF cov
     fn_out=zen.${jd}.sum.${label}.frf.tavg.spw_range_${spw_range}.cov.npy
 	
-    cmd="FRF_noise_cov_run.py ${waterfall_files}  --tol ${tol} \
+    cmd="FRF_noise_cov_run.py ${waterfall_file}  --tol ${tol} \
       --fn_out ${fn_out} --clobber --verbose --spw_range ${spw_range} \
       --ninterleave ${ninterleave} ${pf_arg}"		   
     echo ${cmd}

--- a/pipelines/h4c/post_processing/v7_interleave/post_lstbin_frate/task_scripts/do_FRF_COV.sh
+++ b/pipelines/h4c/post_processing/v7_interleave/post_lstbin_frate/task_scripts/do_FRF_COV.sh
@@ -15,7 +15,8 @@ prefilter_zero_frate="${5}"
 ninterleave="${6}"
 #clobber="true"
 
-jd=$(get_jd $fn)
+jd=`echo ${fn} | grep -o "[0-9]\{1,2\}.[0-9]\{5\}"`
+jd="LST.${jd}"
 
 
 # split up spw ranges.
@@ -37,7 +38,7 @@ do
 		echo "No waterfall files exist with ${jd}. This is probably because there are more times than baseline groups."
   else
     # Calculate FRF cov
-    fn_out=zen.${jd}.sum.${label}.frf.tavg.cov.npy
+    fn_out=zen.${jd}.sum.${label}.frf.tavg.spw_range_${spw_range}.cov.npy
 	
     cmd="FRF_noise_cov_run.py ${waterfall_files}  --tol ${tol} \
       --fn_out ${fn_out} --clobber --verbose --spw_range ${spw_range} \

--- a/pipelines/h4c/post_processing/v7_interleave/post_lstbin_frate/task_scripts/do_FRF_COV.sh
+++ b/pipelines/h4c/post_processing/v7_interleave/post_lstbin_frate/task_scripts/do_FRF_COV.sh
@@ -1,0 +1,53 @@
+#! /bin/bash
+set -e
+#export TMPDIR=/lustre/aoc/projects/hera/heramgr/tmp/
+
+#import common functions
+src_dir="$(dirname "$0")"
+source ${src_dir}/_common.sh
+
+
+fn="${1}"
+label="${2}"
+tol="${3}"
+spw_ranges="${4}"
+prefilter_zero_frate="${5}"
+ninterleave="${6}"
+#clobber="true"
+
+jd=$(get_jd $fn)
+int_jd=${jd:0:7}
+if [[ "$int_jd" == *"."* ]]; then
+  jd=`echo ${fn} | grep -o "[0-9]\{1,2\}.[0-9]\{5\}"`
+  jd="LST.${jd}"
+fi
+
+# split up spw ranges.
+spw_ranges="${spw_ranges//,/$' '}"
+# split into array
+read -a spw_ranges_arr <<< ${spw_ranges}
+
+if [ "${prefilter_zero_frate}" = "true" ]
+then
+  pf_arg="--pre_filter_modes_between_lobe_minimum_and_zero"
+else
+  pf_arg=""
+fi
+
+
+baseline_chunk_files=`echo zen.${int_jd}.*.sum.${label}.frf.waterfall.uvh5`
+if echo x"$baseline_chunk_files" | grep '*' > /dev/null; then
+		echo "No waterfall files exist with ${jd}. This is probably because there are more times than baseline groups."
+else
+    echo ${ilabel}
+    # Calculate FRF cov
+    fn_out=zen.${jd}.sum.${label}.frf.tavg.cov.interleave_${ilabel}.npy
+	
+    cmd="FRF_noise_cov_run.py ${baseline_chunk_files}  --tol ${tol} \
+      --fn_out ${fn_out} --clobber --verbose --spw_range ${spw_range} \
+      --ninterleave ${ninterleave} ${pf_arg}"		   
+    echo ${cmd}
+	${cmd}  
+fi
+	    
+

--- a/pipelines/h4c/post_processing/v7_interleave/post_lstbin_frate/task_scripts/do_FRF_COV.sh
+++ b/pipelines/h4c/post_processing/v7_interleave/post_lstbin_frate/task_scripts/do_FRF_COV.sh
@@ -19,8 +19,10 @@ jd=$(get_jd $fn)
 int_jd=${jd:0:7}
 if [[ "$int_jd" == *"."* ]]; then
   jd=`echo ${fn} | grep -o "[0-9]\{1,2\}.[0-9]\{5\}"`
+  int_jd="LST"
   jd="LST.${jd}"
 fi
+
 
 # split up spw ranges.
 spw_ranges="${spw_ranges//,/$' '}"
@@ -35,15 +37,15 @@ else
 fi
 
 
-baseline_chunk_files=`echo zen.${int_jd}.*.sum.${label}.frf.waterfall.uvh5`
-if echo x"$baseline_chunk_files" | grep '*' > /dev/null; then
+waterfall_files=`echo zen.${int_jd}.*.sum.${label}.frf.waterfall.uvh5`
+if echo x"$waterfall_files" | grep '*' > /dev/null; then
 		echo "No waterfall files exist with ${jd}. This is probably because there are more times than baseline groups."
 else
     echo ${ilabel}
     # Calculate FRF cov
     fn_out=zen.${jd}.sum.${label}.frf.tavg.cov.interleave_${ilabel}.npy
 	
-    cmd="FRF_noise_cov_run.py ${baseline_chunk_files}  --tol ${tol} \
+    cmd="FRF_noise_cov_run.py ${waterfall_files}  --tol ${tol} \
       --fn_out ${fn_out} --clobber --verbose --spw_range ${spw_range} \
       --ninterleave ${ninterleave} ${pf_arg}"		   
     echo ${cmd}

--- a/pipelines/h4c/post_processing/v7_interleave/post_lstbin_frate/task_scripts/do_FRF_COV.sh
+++ b/pipelines/h4c/post_processing/v7_interleave/post_lstbin_frate/task_scripts/do_FRF_COV.sh
@@ -43,7 +43,7 @@ if echo x"$waterfall_files" | grep '*' > /dev/null; then
 else
     echo ${ilabel}
     # Calculate FRF cov
-    fn_out=zen.${jd}.sum.${label}.frf.tavg.cov.interleave_${ilabel}.npy
+    fn_out=zen.${jd}.sum.${label}.frf.tavg.cov.npy
 	
     cmd="FRF_noise_cov_run.py ${waterfall_files}  --tol ${tol} \
       --fn_out ${fn_out} --clobber --verbose --spw_range ${spw_range} \

--- a/pipelines/h4c/post_processing/v7_interleave/post_lstbin_frate/task_scripts/do_RECONSTITUTE.sh
+++ b/pipelines/h4c/post_processing/v7_interleave/post_lstbin_frate/task_scripts/do_RECONSTITUTE.sh
@@ -50,7 +50,7 @@ do
             outfilename=zen.${jd}.${sd}.${label}.${ext}.tavg.interleave_${ilabel}.uvh5
             baseline_chunk_files=`echo zen.${int_jd}.*.${sd}.${label}.${ext}.waterfall.tavg.interleave_${ilabel}.uvh5`
             if echo x"$baseline_chunk_files" | grep '*' > /dev/null; then
-		echo "No waterfall files exist with ${jd}. This is probably because there are more times then baseline groups."
+		echo "No waterfall files exist with ${jd}. This is probably because there are more times than baseline groups."
             else
 		cmd="time_chunk_from_baseline_chunks_run.py ${time_chunk_template} --baseline_chunk_files ${baseline_chunk_files} --clobber --time_bounds --outfilename ${outfilename}"
 		echo ${cmd}


### PR DESCRIPTION
Just adds a step in the v7 toml that computes the FRF noise covariance, along with a task script. It will probably need updating once #20 gets merged since the FRF parameters feed into it.

The script `FRF_noise_cov_run.py` currently lives in a personal repo of mine for convenience but can be pushed to an appropriate HERA repo at any point.