### PR TITLE
refactor: use cli-based pspec notebooks for data pipeline

### DIFF
--- a/pipelines/h6c/idr2/v3/post-lstbin/h6c_pspec_14band.toml
+++ b/pipelines/h6c/idr2/v3/post-lstbin/h6c_pspec_14band.toml
@@ -9,81 +9,60 @@ conda_env = "h6c_idr2"
 batch_system = "slurm"
 
 [NOTEBOOK_OPTS]
-nb_template_dir = '/lustre/aoc/projects/hera/h6c-analysis/IDR2/src/hera_notebook_templates/notebooks'
+toml_file = "/lustre/aoc/projects/hera/h6c-analysis/IDR2/makeflow-pspec/h6c_pspec_14band.toml"  # this file
+toml_section = "CONFIG_OPTS"
+kernel = ""
 
-[SPECTRAL_POSTPROCESSING_OPTS]
-band_str = "50.1~62.2,63.7~73.5,74.6~85.4,108.1~115.8,117.3~124.4,125.5~135.9,138.8~147.1,150.3~161.4,161.5~169.9,171.9~180.8,181.6~196.4,198.6~209.7,212.3~220.5,223.8~231.1"  # MHz
-already_inpainted = true
-perform_inpaint = false
-inpaint_min_dly = 500.0  # ns
-inpaint_horizon = 1.0
-inpaint_standoff = 0.0
-inpaint_eigenval_cutoff = 1e-12
-perform_dly_filt = false
-dly_filt_min_dly = 150.0  # ns
-dly_filt_horizon = 1.0
-dly_filt_standoff = 0.0
-dly_filt_eigenval_cutoff = 1e-12
-use_band_avg_nsamples = true
-fm_cut_freq = 100000000.0  # Hz
-pixel_flag_cut = 0.0
-channel_flag_cut = 0.0
+[CONFIG_OPTS] # This section is directly read when running the notebook.
+# General Options
+PLOT = true
+SAVE_RESULTS = true
 
-[TEMPORAL_POSTPROCESSING_OPTS]
-integration_flag_cut = 0.2
-ninterleave = 4
-xtalk_fr = 0.01  # mHz
-fr_spectra_file = "/lustre/aoc/projects/hera/zmartino/hera_frf/spectra_cache/spectra_cache_hera_core.h5"
-fr_quantile_low = 0.05
-fr_quantile_high = 0.95
-fr_eigenval_cutoff = 1e-12
-target_averaging_time = 300  # seconds
-use_corr_matrix = true
-corr_matrix_freq_decimation = 10
-corr_matrix_notch_cutoff = 30  # m
+# Spectral Options
+BAND_STR = "50.1~62.2,63.3~73.5,74.6~85.4,108.0~116.1,117.3~124.4,125.3~136.2,138.3~148.2,150.1~159.2,159.3~169.9,171.9~181.1,181.4~196.4,198.5~208.4,212.3~220.6,224.4~231.1"  # MHz
+ALREADY_INPAINTED = true
+PERFORM_INPAINT = false
+INPAINT_MIN_DLY = 500.0  # ns
+INPAINT_HORIZON = 1.0
+INPAINT_STANDOFF = 0.0
+INPAINT_EIGENVAL_CUTOFF = 1e-12
 
-[PSPEC_OPTS]
-efield_healpix_beam_file = "/lustre/aoc/projects/hera/H4C/beams/NF_HERA_Vivaldi_efield_beam_healpix.fits"
-taper = "bh"
-include_interleave_auto_ps = false
-store_window_functions = false
+PERFORM_DLY_FILT = false
+DLY_FILT_MIN_DLY = 150.0  # ns
+DLY_FILT_HORIZON = 1.0
+DLY_FILT_STANDOFF = 0.0
+DLY_FILT_EIGENVAL_CUTOFF = 1e-12
+
+USE_BAND_AVG_NSAMPLES = true
+FM_CUT_FREQ = 100000000.0  # Hz
+PIXEL_FLAG_CUT = 0.0
+CHANNEL_FLAG_CUT = 0.0
+
+# Temporal options
+INTEGRATION_FLAG_CUT = 0.2
+NINTERLEAVE = 4
+XTALK_FR = 0.01  # mHz
+FR_SPECTRA_FILE = "/lustre/aoc/projects/hera/zmartino/hera_frf/spectra_cache/spectra_cache_hera_core.h5"
+FR_QUANTILE_LOW = 0.05
+FR_QUANTILE_HIGH = 0.95
+FR_EIGENVAL_CUTOFF = 1e-12
+TARGET_AVERAGING_TIME = 300  # seconds
+
+# pspec options
+EFIELD_HEALPIX_BEAM_FILE = "/lustre/aoc/projects/hera/H4C/beams/NF_HERA_Vivaldi_efield_beam_healpix.fits"
+TAPER = "bh"
+INCLUDE_INTERLEAVE_AUTO_PS = false
+STORE_WINDOW_FUNCTIONS = false
 
 [WorkFlow]
-actions = ["SINGLE_BASELINE_POSTPROCESSING_AND_PSPEC",
-          ]
+actions = [
+    "SINGLE_BASELINE_POSTPROCESSING_AND_PSPEC",
+]
 
 [SINGLE_BASELINE_POSTPROCESSING_AND_PSPEC]
-args = ["{basename}",
-        "${NOTEBOOK_OPTS:nb_template_dir}",
-        "${SPECTRAL_POSTPROCESSING_OPTS:band_str}",
-        "${SPECTRAL_POSTPROCESSING_OPTS:already_inpainted}",
-        "${SPECTRAL_POSTPROCESSING_OPTS:perform_inpaint}",
-        "${SPECTRAL_POSTPROCESSING_OPTS:inpaint_min_dly}",
-        "${SPECTRAL_POSTPROCESSING_OPTS:inpaint_horizon}",
-        "${SPECTRAL_POSTPROCESSING_OPTS:inpaint_standoff}",
-        "${SPECTRAL_POSTPROCESSING_OPTS:inpaint_eigenval_cutoff}",
-        "${SPECTRAL_POSTPROCESSING_OPTS:perform_dly_filt}",
-        "${SPECTRAL_POSTPROCESSING_OPTS:dly_filt_min_dly}",
-        "${SPECTRAL_POSTPROCESSING_OPTS:dly_filt_horizon}",
-        "${SPECTRAL_POSTPROCESSING_OPTS:dly_filt_standoff}",
-        "${SPECTRAL_POSTPROCESSING_OPTS:dly_filt_eigenval_cutoff}",
-        "${SPECTRAL_POSTPROCESSING_OPTS:use_band_avg_nsamples}",
-        "${SPECTRAL_POSTPROCESSING_OPTS:fm_cut_freq}",
-        "${SPECTRAL_POSTPROCESSING_OPTS:pixel_flag_cut}",
-        "${SPECTRAL_POSTPROCESSING_OPTS:channel_flag_cut}",
-        "${TEMPORAL_POSTPROCESSING_OPTS:integration_flag_cut}",
-        "${TEMPORAL_POSTPROCESSING_OPTS:ninterleave}",
-        "${TEMPORAL_POSTPROCESSING_OPTS:xtalk_fr}",
-        "${TEMPORAL_POSTPROCESSING_OPTS:fr_spectra_file}",
-        "${TEMPORAL_POSTPROCESSING_OPTS:fr_quantile_low}",
-        "${TEMPORAL_POSTPROCESSING_OPTS:fr_quantile_high}",
-        "${TEMPORAL_POSTPROCESSING_OPTS:fr_eigenval_cutoff}",
-        "${TEMPORAL_POSTPROCESSING_OPTS:target_averaging_time}",
-        "${TEMPORAL_POSTPROCESSING_OPTS:use_corr_matrix}",
-        "${TEMPORAL_POSTPROCESSING_OPTS:corr_matrix_freq_decimation}",
-        "${TEMPORAL_POSTPROCESSING_OPTS:corr_matrix_notch_cutoff}",
-        "${PSPEC_OPTS:efield_healpix_beam_file}",
-        "${PSPEC_OPTS:taper}",
-        "${PSPEC_OPTS:include_interleave_auto_ps}",
-        "${PSPEC_OPTS:store_window_functions}",
-        ]
+args = [
+    "{basename}",
+    "${NOTEBOOK_OPTS:toml_file}",
+    "${NOTEBOOK_OPTS:toml_section}",
+    "${Options:conda_env}",
+]

--- a/pipelines/h6c/idr2/v3/post-lstbin/task_scripts/do_SINGLE_BASELINE_POSTPROCESSING_AND_PSPEC.sh
+++ b/pipelines/h6c/idr2/v3/post-lstbin/task_scripts/do_SINGLE_BASELINE_POSTPROCESSING_AND_PSPEC.sh
@@ -12,88 +12,31 @@ source ${src_dir}/_common.sh
 # 1 - (raw) filename
 # 2+ - various settings
 fn=${1}
-nb_template_dir=${2}
-band_str=${3}
-already_inpainted=${4}
-perform_inpaint=${5}
-inpaint_min_dly=${6}
-inpaint_horizon=${7}
-inpaint_standoff=${8}
-inpaint_eigenval_cutoff=${9}
-perform_dly_filt=${10}
-dly_filt_min_dly=${11}
-dly_filt_horizon=${12}
-dly_filt_standoff=${13}
-dly_filt_eigenval_cutoff=${14}
-use_band_avg_nsamples=${15}
-fm_cut_freq=${16}
-pixel_flag_cut=${17}
-channel_flag_cut=${18}
-integration_flag_cut=${19}
-ninterleave=${20}
-xtalk_fr=${21}
-fr_spectra_file=${22}
-fr_quantile_low=${23}
-fr_quantile_high=${24}
-fr_eigenval_cutoff=${25}
-target_averaging_time=${26}
-use_corr_matrix=${27}
-corr_matrix_freq_decimation=${28}
-corr_matrix_notch_cutoff=${29}
-efield_healpix_beam_file=${30}
-taper=${31}
-include_interleave_auto_ps=${32}
-store_window_functions=${33}
+toml_file=${2}
+toml_section=${3}
+kernel=${4}
 
-# Export variables used by the notebook
-full_file_path="$(cd "$(dirname "$fn")" && pwd)/$(basename "$fn")"
+# --variables used by the notebook
+outdir=$(cd "$(dirname "$fn")" && pwd)
+full_file_path="$outdir/$(basename "$fn")"
 echo "Performing single baseline postprocessing and power spectrum estimation on ${full_file_path}"
-export SINGLE_BL_FILE=${full_file_path}
-export OUT_PSPEC_FILE=${full_file_path%.uvh5}.pspec.h5
-export OUT_TAVG_PSPEC_FILE=${full_file_path%.uvh5}.tavg_pspec.h5
-export BAND_STR=${band_str}
-export ALREADY_INPAINTED=${already_inpainted}
-export PERFORM_INPAINT=${perform_inpaint}
-export INPAINT_MIN_DLY=${inpaint_min_dly}
-export INPAINT_HORIZON=${inpaint_horizon}
-export INPAINT_STANDOFF=${inpaint_standoff}
-export INPAINT_EIGENVAL_CUTOFF=${inpaint_eigenval_cutoff}
-export PERFORM_DLY_FILT=${perform_dly_filt}
-export DLY_FILT_MIN_DLY=${dly_filt_min_dly}
-export DLY_FILT_HORIZON=${dly_filt_horizon}
-export DLY_FILT_STANDOFF=${dly_filt_standoff}
-export DLY_FILT_EIGENVAL_CUTOFF=${dly_filt_eigenval_cutoff}
-export USE_BAND_AVG_NSAMPLES=${use_band_avg_nsamples}
-export FM_CUT_FREQ=${fm_cut_freq}
-export PIXEL_FLAG_CUT=${pixel_flag_cut}
-export CHANNEL_FLAG_CUT=${channel_flag_cut}
-export INTEGRATION_FLAG_CUT=${integration_flag_cut}
-export NINTERLEAVE=${ninterleave}
-export XTALK_FR=${xtalk_fr}
-export FR_SPECTRA_FILE=${fr_spectra_file}
-export FR_QUANTILE_LOW=${fr_quantile_low}
-export FR_QUANTILE_HIGH=${fr_quantile_high}
-export FR_EIGENVAL_CUTOFF=${fr_eigenval_cutoff}
-export TARGET_AVERAGING_TIME=${target_averaging_time}
-export USE_CORR_MATRIX=${use_corr_matrix}
-export CORR_MATRIX_FREQ_DECIMATION=${corr_matrix_freq_decimation}
-export CORR_MATRIX_NOTCH_CUTOFF=${corr_matrix_notch_cutoff}
-export EFIELD_HEALPIX_BEAM_FILE=${efield_healpix_beam_file}
-export TAPER=${taper}
-export INCLUDE_INTERLEAVE_AUTO_PS=${include_interleave_auto_ps}
-export STORE_WINDOW_FUNCTIONS=${store_window_functions}
-# TODO: add LST_RANGE_HOURS when we want to parameterize that
+
 
 # check if file is not just autocorrelaitons and that neither polarization is fully flagged
 if python ${src_dir}/check_single_bl_file.py ${full_file_path} --skip_autos --skip_outriggers; then
     # Execute jupyter notebook
-    nb_outfile=${full_file_path%.uvh5}.single_baseline_postprocessing_and_pspec.html
-    jupyter nbconvert --output=${nb_outfile} \
-    --to html \
-    --ExecutePreprocessor.allow_errors=False \
-    --ExecutePreprocessor.timeout=-1 \
-    --execute ${nb_template_dir}/single_baseline_postprocessing_and_pspec.ipynb
-    echo Finished running single baseline postprocessing and power spectrum estimation notebook for ${fn} at $(date) and writing results to ${nb_outfile}
+    nb_outfile=${full_file_path%.uvh5}.single_baseline_postprocessing_and_pspec
+    
+    runopts="--output-dir ${outdir} -k ${kernel} --toml ${toml_file} --toml-section ${toml_section}"
+    cfg="--basename ${nb_outfile} --SINGLE-BL-FILE ${full_file_path} --OUT-PSPEC-FILE=${full_file_path%.uvh5}.pspec.h5"
+    echo "Runopts: ${runopts}"
+    echo "Config: ${cfg}"
+
+    cmd="hnote run ${runopts} single_baseline_postprocessing_and_pspec ${cfg}"
+    echo $cmd
+    eval $cmd
+
+    echo Finished running single baseline postprocessing and power spectrum estimation notebook for ${fn} at $(date) and writing results to ${nb_outfile}.ipynb
 
     # Check to see that output file was correctly produced
     if [ -f "${fn%.uvh5}.pspec.h5" ]; then

--- a/pipelines/h6c/idr2/v3/post-lstbin/task_scripts/do_SINGLE_BASELINE_POSTPROCESSING_AND_PSPEC.sh
+++ b/pipelines/h6c/idr2/v3/post-lstbin/task_scripts/do_SINGLE_BASELINE_POSTPROCESSING_AND_PSPEC.sh
@@ -36,7 +36,7 @@ if python ${src_dir}/check_single_bl_file.py ${full_file_path} --skip_autos --sk
     echo $cmd
     eval $cmd
 
-    echo Finished running single baseline postprocessing and power spectrum estimation notebook for ${fn} at $(date) and writing results to ${nb_outfile}.ipynb
+    echo Finished running single baseline postprocessing and power spectrum estimation notebook for ${fn} at $(date) and writing results to ${nb_outfile}.ipynb and ${nb_outfile}.html
 
     # Check to see that output file was correctly produced
     if [ -f "${fn%.uvh5}.pspec.h5" ]; then

--- a/pipelines/validation/h6c/post-lstbin/task_scripts/do_SINGLE_BASELINE_POSTPROCESSING_AND_PSPEC.sh
+++ b/pipelines/validation/h6c/post-lstbin/task_scripts/do_SINGLE_BASELINE_POSTPROCESSING_AND_PSPEC.sh
@@ -36,7 +36,7 @@ if python ${src_dir}/check_single_bl_file.py ${full_file_path} --skip_autos --sk
     echo $cmd
     eval $cmd
 
-    echo Finished running single baseline postprocessing and power spectrum estimation notebook for ${fn} at $(date) and writing results to ${nb_outfile}.ipynb
+    echo Finished running single baseline postprocessing and power spectrum estimation notebook for ${fn} at $(date) and writing results to ${nb_outfile}.ipynb and ${nb_outfile}.html
 
     # Check to see that output file was correctly produced
     if [ -f "${fn%.uvh5}.pspec.h5" ]; then


### PR DESCRIPTION
Switch to using the new CLI-based notebooks for the single-baseline pspec.