### PR TITLE
Add merge single baselines

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -132,3 +132,4 @@ dmypy.json
 
 # OSX files
 *.DS_Store
+.qodo

--- a/pipelines/h6c/idr2/v3/post-lstbin/h6c_pspec_14band.toml
+++ b/pipelines/h6c/idr2/v3/post-lstbin/h6c_pspec_14band.toml
@@ -80,3 +80,4 @@ prereq_chunk_size = "all"
 args = [
     "{basename}",
 ]
+mem=40000

--- a/pipelines/h6c/idr2/v3/post-lstbin/h6c_pspec_14band.toml
+++ b/pipelines/h6c/idr2/v3/post-lstbin/h6c_pspec_14band.toml
@@ -48,6 +48,9 @@ FR_QUANTILE_HIGH = 0.95
 FR_EIGENVAL_CUTOFF = 1e-12
 TARGET_AVERAGING_TIME = 300  # seconds
 
+LST_MIN = 1.25  # 30 minutes inside H1C, because FRF's bleed structure (galaxy and pulsars)
+LST_MAX = 5.75
+
 # pspec options
 EFIELD_HEALPIX_BEAM_FILE = "/lustre/aoc/projects/hera/H4C/beams/NF_HERA_Vivaldi_efield_beam_healpix.fits"
 TAPER = "bh"

--- a/pipelines/h6c/idr2/v3/post-lstbin/h6c_pspec_14band.toml
+++ b/pipelines/h6c/idr2/v3/post-lstbin/h6c_pspec_14band.toml
@@ -80,4 +80,4 @@ prereq_chunk_size = "all"
 args = [
     "{basename}",
 ]
-mem=40000
+mem=60000

--- a/pipelines/h6c/idr2/v3/post-lstbin/h6c_pspec_14band.toml
+++ b/pipelines/h6c/idr2/v3/post-lstbin/h6c_pspec_14band.toml
@@ -80,4 +80,4 @@ prereq_chunk_size = "all"
 args = [
     "{basename}",
 ]
-mem=60000
+mem=100000

--- a/pipelines/h6c/idr2/v3/post-lstbin/h6c_pspec_14band.toml
+++ b/pipelines/h6c/idr2/v3/post-lstbin/h6c_pspec_14band.toml
@@ -57,6 +57,7 @@ STORE_WINDOW_FUNCTIONS = false
 [WorkFlow]
 actions = [
     "SINGLE_BASELINE_POSTPROCESSING_AND_PSPEC",
+    "MERGE_SINGLE_BASELINE_FILES",
 ]
 
 [SINGLE_BASELINE_POSTPROCESSING_AND_PSPEC]
@@ -65,4 +66,14 @@ args = [
     "${NOTEBOOK_OPTS:toml_file}",
     "${NOTEBOOK_OPTS:toml_section}",
     "${Options:conda_env}",
+]
+
+[MERGE_SINGLE_BASELINE_FILES]
+prereqs = [
+    "SINGLE_BASELINE_POSTPROCESSING_AND_PSPEC",
+]
+chunk_size = "all"
+prereq_chunk_size = "all"
+args = [
+    "{basename}",
 ]

--- a/pipelines/h6c/idr2/v3/post-lstbin/task_scripts/do_MERGE_SINGLE_BASELINE_FILES.sh
+++ b/pipelines/h6c/idr2/v3/post-lstbin/task_scripts/do_MERGE_SINGLE_BASELINE_FILES.sh
@@ -1,0 +1,31 @@
+#! /bin/bash
+set -e
+
+# This script generates a notebook that processes a single-baseline file, typically redundantly-averaged and
+# LST-binned, through to power spectra
+
+src_dir="$(dirname "$0")"
+source ${src_dir}/_common.sh
+
+# Parameters are set in the configuration file. Here we define their positions,
+# which must be consistent with the config.
+# 1 - (raw) filename
+# 2+ - various settings
+fn=${1}
+
+# --variables used by the notebook
+outdir=$(cd "$(dirname "$fn")" && pwd)
+pattern="$outdir/*.pspec.h5"
+outpath="$outdir/baselines_merged"
+full_file_path="$outdir/$(basename "$fn")"
+cmd="pspec fast-merge-baselines --pattern '${pattern}' --group stokespol --names interleave_averaged --names time_and_interleave_averaged --outpath ${outpath} --extras frf_losses"
+echo $cmd
+eval $cmd
+
+# Check to see that output file was correctly produced
+if [ -f "${outpath}.pspec.h5" ]; then
+    echo Resulting $f found.
+else
+    echo $f not produced.
+    exit 1
+fi

--- a/pipelines/h6c/idr2/v3/post-lstbin/task_scripts/do_MERGE_SINGLE_BASELINE_FILES.sh
+++ b/pipelines/h6c/idr2/v3/post-lstbin/task_scripts/do_MERGE_SINGLE_BASELINE_FILES.sh
@@ -15,10 +15,28 @@ fn=${1}
 
 # --variables used by the notebook
 outdir=$(cd "$(dirname "$fn")" && pwd)
+
+# First do the non-time-averaged pspecs
 pattern="$outdir/*.pspec.h5"
 outpath="$outdir/baselines_merged"
 full_file_path="$outdir/$(basename "$fn")"
-cmd="pspec fast-merge-baselines --pattern '${pattern}' --group stokespol --names interleave_averaged --names time_and_interleave_averaged --outpath ${outpath} --extras frf_losses"
+cmd="pspec fast-merge-baselines --pattern '${pattern}' --group stokespol --names interleave_averaged --outpath ${outpath} --extras frf_losses"
+echo $cmd
+eval $cmd
+
+# Check to see that output file was correctly produced
+if [ -f "${outpath}.pspec.h5" ]; then
+    echo Resulting $f found.
+else
+    echo $f not produced.
+    exit 1
+fi
+
+# Now the time-averaged pspecs
+pattern="$outdir/*.tavg.pspec.h5"
+outpath="$outdir/baselines_merged.tavg"
+full_file_path="$outdir/$(basename "$fn")"
+cmd="pspec fast-merge-baselines --pattern '${pattern}' --group stokespol --names time_and_interleave_averaged --outpath ${outpath} --extras frf_losses"
 echo $cmd
 eval $cmd
 

--- a/pipelines/h6c/idr2/v3/post-lstbin/task_scripts/do_MERGE_SINGLE_BASELINE_FILES.sh
+++ b/pipelines/h6c/idr2/v3/post-lstbin/task_scripts/do_MERGE_SINGLE_BASELINE_FILES.sh
@@ -17,7 +17,7 @@ fn=${1}
 outdir=$(cd "$(dirname "$fn")" && pwd)
 
 # First do the non-time-averaged pspecs
-pattern="$outdir/*.pspec.h5"
+pattern="$outdir/*.sum.pspec.h5"
 outpath="$outdir/baselines_merged"
 full_file_path="$outdir/$(basename "$fn")"
 cmd="pspec fast-merge-baselines --pattern '${pattern}' --group stokespol --names interleave_averaged --outpath ${outpath} --extras frf_losses"
@@ -33,7 +33,7 @@ else
 fi
 
 # Now the time-averaged pspecs
-pattern="$outdir/*.tavg.pspec.h5"
+pattern="$outdir/*.sum.tavg.pspec.h5"
 outpath="$outdir/baselines_merged.tavg"
 full_file_path="$outdir/$(basename "$fn")"
 cmd="pspec fast-merge-baselines --pattern '${pattern}' --group stokespol --names time_and_interleave_averaged --outpath ${outpath} --extras frf_losses"

--- a/pipelines/h6c/idr2/v3/post-lstbin/task_scripts/do_MERGE_SINGLE_BASELINE_FILES.sh
+++ b/pipelines/h6c/idr2/v3/post-lstbin/task_scripts/do_MERGE_SINGLE_BASELINE_FILES.sh
@@ -19,7 +19,6 @@ outdir=$(cd "$(dirname "$fn")" && pwd)
 # First do the non-time-averaged pspecs
 pattern="$outdir/*.sum.pspec.h5"
 outpath="$outdir/baselines_merged"
-full_file_path="$outdir/$(basename "$fn")"
 cmd="pspec fast-merge-baselines --pattern '${pattern}' --group stokespol --names interleave_averaged --outpath ${outpath} --extras frf_losses"
 echo $cmd
 eval $cmd
@@ -35,7 +34,6 @@ fi
 # Now the time-averaged pspecs
 pattern="$outdir/*.sum.tavg.pspec.h5"
 outpath="$outdir/baselines_merged.tavg"
-full_file_path="$outdir/$(basename "$fn")"
 cmd="pspec fast-merge-baselines --pattern '${pattern}' --group stokespol --names time_and_interleave_averaged --outpath ${outpath} --extras frf_losses"
 echo $cmd
 eval $cmd

--- a/pipelines/validation/h6c/post-lstbin/h6c_pspec_14band.toml
+++ b/pipelines/validation/h6c/post-lstbin/h6c_pspec_14band.toml
@@ -48,6 +48,9 @@ FR_QUANTILE_HIGH = 0.95
 FR_EIGENVAL_CUTOFF = 1e-12
 TARGET_AVERAGING_TIME = 300  # seconds
 
+LST_MIN = 1.25  # 30 minutes inside H1C, because FRF's bleed structure (galaxy and pulsars)
+LST_MAX = 5.75
+
 # pspec options
 EFIELD_HEALPIX_BEAM_FILE = "/lustre/aoc/projects/hera/H4C/beams/NF_HERA_Vivaldi_efield_beam_healpix.fits"
 TAPER = "bh"
@@ -57,6 +60,7 @@ STORE_WINDOW_FUNCTIONS = false
 [WorkFlow]
 actions = [
     "SINGLE_BASELINE_POSTPROCESSING_AND_PSPEC",
+    "MERGE_SINGLE_BASELINE_FILES",
 ]
 
 [SINGLE_BASELINE_POSTPROCESSING_AND_PSPEC]
@@ -66,3 +70,15 @@ args = [
     "${NOTEBOOK_OPTS:toml_section}",
     "${Options:conda_env}",
 ]
+
+
+[MERGE_SINGLE_BASELINE_FILES]
+prereqs = [
+    "SINGLE_BASELINE_POSTPROCESSING_AND_PSPEC",
+]
+chunk_size = "all"
+prereq_chunk_size = "all"
+args = [
+    "{basename}",
+]
+mem=100000

--- a/pipelines/validation/h6c/post-lstbin/task_scripts/do_MERGE_SINGLE_BASELINE_FILES.sh
+++ b/pipelines/validation/h6c/post-lstbin/task_scripts/do_MERGE_SINGLE_BASELINE_FILES.sh
@@ -1,0 +1,47 @@
+#! /bin/bash
+set -e
+
+# This script generates a notebook that processes a single-baseline file, typically redundantly-averaged and
+# LST-binned, through to power spectra
+
+src_dir="$(dirname "$0")"
+source ${src_dir}/_common.sh
+
+# Parameters are set in the configuration file. Here we define their positions,
+# which must be consistent with the config.
+# 1 - (raw) filename
+# 2+ - various settings
+fn=${1}
+
+# --variables used by the notebook
+outdir=$(cd "$(dirname "$fn")" && pwd)
+
+# First do the non-time-averaged pspecs
+pattern="$outdir/*.sum.pspec.h5"
+outpath="$outdir/baselines_merged"
+cmd="pspec fast-merge-baselines --pattern '${pattern}' --group stokespol --names interleave_averaged --outpath ${outpath} --extras frf_losses"
+echo $cmd
+eval $cmd
+
+# Check to see that output file was correctly produced
+if [ -f "${outpath}.pspec.h5" ]; then
+    echo Resulting $f found.
+else
+    echo $f not produced.
+    exit 1
+fi
+
+# Now the time-averaged pspecs
+pattern="$outdir/*.sum.tavg.pspec.h5"
+outpath="$outdir/baselines_merged.tavg"
+cmd="pspec fast-merge-baselines --pattern '${pattern}' --group stokespol --names time_and_interleave_averaged --outpath ${outpath} --extras frf_losses"
+echo $cmd
+eval $cmd
+
+# Check to see that output file was correctly produced
+if [ -f "${outpath}.pspec.h5" ]; then
+    echo Resulting $f found.
+else
+    echo $f not produced.
+    exit 1
+fi


### PR DESCRIPTION
This adds a new do-script "MERGE_SINGLE_BASELINE_FILES" that merges the output single-baseline pspec files, for convenience in the summary notebook(s).